### PR TITLE
Refactoring Immutabilité + PartnerInventory

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -2,10 +2,10 @@ import sqlite3
 from pathlib import Path
 from typing import Iterable
 
-from app.audit import InMemoryAudit
 from app.context import Context
 from infra.sql.sql_audit_repo import SqlAuditRepo
 from infra.sql.sql_delivery_request_repo import SqlDeliveryRequestRepo
+from infra.sql.sql_partner_inventory_repo import SqlPartnerInventoryRepo
 from infra.sql.sql_sales_report_repo import SqlSalesReportRepo
 from policies.identity import Actor, Role
 
@@ -55,6 +55,7 @@ def make_ctx(
         catalog=catalog,
         dr_repo=SqlDeliveryRequestRepo(conn),
         sr_repo=SqlSalesReportRepo(conn),
+        pi_repo=SqlPartnerInventoryRepo(conn),
         audit=SqlAuditRepo(conn),
     )
 

--- a/app/context.py
+++ b/app/context.py
@@ -8,6 +8,7 @@ from typing import Iterable
 # from app.audit import InMemoryAudit
 from infra.sql.sql_audit_repo import SqlAuditRepo
 from infra.sql.sql_delivery_request_repo import SqlDeliveryRequestRepo
+from infra.sql.sql_partner_inventory_repo import SqlPartnerInventoryRepo
 from infra.sql.sql_sales_report_repo import SqlSalesReportRepo
 
 
@@ -16,4 +17,5 @@ class Context:
     catalog: Iterable[str]
     dr_repo: SqlDeliveryRequestRepo
     sr_repo: SqlSalesReportRepo
+    pi_repo: SqlPartnerInventoryRepo
     audit: SqlAuditRepo

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,6 +1,7 @@
-# from app.errors import NotFound
-from .context import Context
-from .errors import NotFound
+from domain.sales_report import SalesReport
+from app.context import Context
+from app.errors import NotFound
+from infra.errors import DataIntegrityError
 
 
 def get_dr_or_raise(ctx: Context, dr_id: int):
@@ -15,3 +16,20 @@ def get_sr_or_raise(ctx: Context, sr_id: int):
     if not sr:
         raise NotFound(f"sales report not found: {sr_id}")
     return sr
+
+
+def restore_quantities_or_raise(
+    ctx: Context, sr: SalesReport, autocommit: bool
+) -> None:
+    missing_items_ids = []
+    for it in sr.items:
+        pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
+        if pi is None:
+            missing_items_ids.append(it.book_id)
+            continue
+        pi = pi.restore_sale(it.quantity)
+        ctx.pi_repo.save(pi, autocommit=False)
+    if missing_items_ids:
+        raise DataIntegrityError(
+            f"Sales report with id {sr.id} contains following items ({', '.join(missing_items_ids)}), for which no inventory line exists"
+        )

--- a/app/queries.py
+++ b/app/queries.py
@@ -1,10 +1,29 @@
 # from collections import defaultdict
-from typing import List
+from typing import Dict, List
 
 from domain.sales_report import SalesReport
+from infra.sql.sql_partner_inventory_repo import SqlPartnerInventoryRepo
 
 
 def reports_by_partner(
     reports: List[SalesReport], partner_id: str
 ) -> List[SalesReport]:
     return [r for r in reports if r.partner_id == partner_id]
+
+
+def get_partner_inventory(
+    partner_id: str, pi_repo: SqlPartnerInventoryRepo
+) -> Dict[str, int]:
+    rows = (
+        pi_repo.conn.cursor()
+        .execute(
+            """
+        SELECT book_sku, current_quantity
+        FROM partner_inventories
+        WHERE partner_id = ?
+        """,
+            (partner_id,),
+        )
+        .fetchall()
+    )
+    return {sku: qty for sku, qty in rows}

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -144,7 +144,9 @@ def submit_sales_report(
     if actor.role != Role.PARTNER:
         raise Forbidden("only PARTNER can submit a sales report")
 
-    report = SalesReport(partner_id=actor.partner_id, items=payload)  # invariants SR
+    report = SalesReport(
+        id=None, partner_id=actor.partner_id, items=payload
+    )  # invariants SR
     validate_report_items_in_catalog(report, ctx.catalog)  # policy externe
 
     working = {}
@@ -164,6 +166,7 @@ def submit_sales_report(
         for pi in working.values():
             ctx.pi_repo.save(pi, autocommit=False)
         ctx.sr_repo.conn.commit()
+        report = get_sr_or_raise(ctx, sr_id)
     except Exception:
         ctx.sr_repo.conn.rollback()
         raise
@@ -200,12 +203,12 @@ def void_sales_report(
             autocommit=False,
         )
         ctx.sr_repo.conn.commit()
+        report = get_sr_or_raise(ctx, sr_id)
     except Exception:
         ctx.sr_repo.conn.rollback()
         raise
 
-    # ctx.sr_repo.mark_void(sr_id)
-    return sr_id, get_sr_or_raise(ctx, sr_id)
+    return sr_id, report
 
 
 def get_sales_report(ctx: Context, actor: Actor, sr_id: int) -> SalesReport | None:

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -85,20 +85,27 @@ def reject_delivery_request(
     if reason is None or not str(reason).strip():
         raise ValidationError("reject reason is required")
 
-    dr = get_dr_or_raise(ctx, dr_id)
+    try:
+        dr = get_dr_or_raise(ctx, dr_id)
 
-    # Audit requis (si audit absent/KO -> on échoue)
-    ctx.audit.record(
-        {
-            "type": "DR_REJECTED",
-            "target_type": "delivery_request",
-            "target_id": dr_id,
-            "reason": reason,
-        }
-    )
+        # Audit requis (si audit absent/KO -> on échoue)
+        ctx.audit.record(
+            {
+                "type": "DR_REJECTED",
+                "target_type": "delivery_request",
+                "target_id": dr_id,
+                "reason": reason,
+            },
+            autocommit=False,
+        )
 
-    # Transition métier (idéalement: l'entité refuse si state != SUBMITTED)
-    dr.reject()
+        # Transition métier (idéalement: l'entité refuse si state != SUBMITTED)
+        dr.reject()
+        ctx.dr_repo.save_status(dr_id, dr.status, autocommit=False)
+        ctx.dr_repo.conn.commit()
+    except Exception:
+        ctx.dr_repo.conn.rollback()
+        raise
 
     return dr_id, dr
 
@@ -109,17 +116,22 @@ def mark_delivered(
     if actor.role is not Role.ADMIN:
         raise Forbidden("only ADMIN can mark a delivery request delivered")
 
-    dr = get_dr_or_raise(ctx, dr_id)
-    dr.mark_delivered()
-    ctx.dr_repo.save_status(dr_id, dr.status)
-    for items in dr.items:
-        pi = ctx.pi_repo.get(dr.partner_id, items.book_id)
-        if pi is None:
-            pi = PartnerInventory(
-                partner_id=dr.partner_id, book_sku=items.book_id, current_quantity=0
-            )
-        pi.deliver(items.quantity)
-        ctx.pi_repo.save(pi)
+    try:
+        dr = get_dr_or_raise(ctx, dr_id)
+        dr.mark_delivered()
+        for items in dr.items:
+            pi = ctx.pi_repo.get(dr.partner_id, items.book_id)
+            if pi is None:
+                pi = PartnerInventory(
+                    partner_id=dr.partner_id, book_sku=items.book_id, current_quantity=0
+                )
+            pi.deliver(items.quantity)
+            ctx.pi_repo.save(pi, autocommit=False)
+        ctx.dr_repo.save_status(dr_id, dr.status, autocommit=False)
+        ctx.dr_repo.conn.commit()
+    except Exception:
+        ctx.dr_repo.conn.rollback()
+        raise
     return dr_id, dr
 
 
@@ -132,10 +144,7 @@ def submit_sales_report(
 
     report = SalesReport(partner_id=actor.partner_id, items=payload)  # invariants SR
     validate_report_items_in_catalog(report, ctx.catalog)  # policy externe
-    # validate_sales_report_against_stock(
-    #     report=report, dr_repo=ctx.dr_repo, sr_repo=ctx.sr_repo
-    # )
-    # update_report_quantities_against_stock(report, ctx.pi_repo)
+
     working = {}
     for it in report.items:
         key = (report.partner_id, it.book_id)
@@ -146,11 +155,16 @@ def submit_sales_report(
                     f"Cannot report sale of {it.quantity} for {it.book_id}, no copy available"
                 )
             pi.reportSale(it.quantity)
-            working[key] = pi.clone()
+            working[key] = pi  # .clone()
 
-    sr_id = ctx.sr_repo.create(report)  # persistance mémoire
-    for pi in working.values():
-        ctx.pi_repo.save(pi)
+    try:
+        sr_id = ctx.sr_repo.create(report, autocommit=False)  # persistance mémoire
+        for pi in working.values():
+            ctx.pi_repo.save(pi, autocommit=False)
+        ctx.sr_repo.conn.commit()
+    except Exception:
+        ctx.sr_repo.conn.rollback()
+        raise
     return sr_id, report
 
 
@@ -167,53 +181,29 @@ def void_sales_report(
     if sr.voided:
         raise AlreadyVoided(f"sales report with id {sr_id} is already voided")
 
-    for it in sr.items:
-        pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
-        pi.restoreSales(it.quantity)
-        ctx.pi_repo.save(pi)
+    try:
+        for it in sr.items:
+            pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
+            pi.restoreSales(it.quantity)
+            ctx.pi_repo.save(pi, autocommit=False)
 
-    ctx.sr_repo.mark_void(sr_id)
-
-    ctx.audit.record(
-        {
-            "type": "SR_VOIDED",
-            "target_type": "sales_report",
-            "target_id": sr_id,
-            "reason": reason,
-        }
-    )
+        ctx.sr_repo.mark_void(sr_id, autocommit=False)
+        ctx.audit.record(
+            {
+                "type": "SR_VOIDED",
+                "target_type": "sales_report",
+                "target_id": sr_id,
+                "reason": reason,
+            },
+            autocommit=False,
+        )
+        ctx.sr_repo.conn.commit()
+    except Exception:
+        ctx.sr_repo.conn.rollback()
+        raise
 
     # ctx.sr_repo.mark_void(sr_id)
     return sr_id, get_sr_or_raise(ctx, sr_id)
-
-
-# def list_reports_by_partner(
-#     *,
-#     actor: Actor,
-#     partner_id: str,
-#     sr_repo: InMemorySalesReportRepo,
-# ) -> List[SalesReport]:
-#     # Rule: ADMIN must provide a partner_id (no "list all" shortcut in this use-case).
-#     if actor.role is not Role.ADMIN:
-#         raise Forbidden("only ADMIN can list reports for an arbitrary partner")
-
-#     if not partner_id:
-#         raise ValueError("partner_id is required")
-
-#     return reports_by_partner(sr_repo.list_all(), partner_id)
-
-
-# def list_my_reports(
-#     *,
-#     actor: Actor,
-#     sr_repo: InMemorySalesReportRepo,
-# ) -> List[SalesReport]:
-#     # Rule: "my reports" is a PARTNER-only intention.
-#     if actor.role is not Role.PARTNER:
-#         raise Forbidden("only PARTNER can list their own reports")
-
-#     # Actor invariant guarantees partner_id is present for PARTNER.
-#     return reports_by_partner(sr_repo.list_all(), actor.partner_id)
 
 
 def get_sales_report(ctx: Context, actor: Actor, sr_id: int) -> SalesReport | None:

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -156,7 +156,7 @@ def submit_sales_report(
                 raise InsufficientStock(
                     f"Cannot report sale of {it.quantity} for {it.book_id}, no copy available"
                 )
-            pi = pi.reportSale(it.quantity)
+            pi = pi.report_sale(it.quantity)
             working[key] = pi  # .clone()
 
     try:
@@ -187,7 +187,7 @@ def void_sales_report(
     try:
         for it in sr.items:
             pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
-            pi = pi.restoreSales(it.quantity)
+            pi = pi.restore_sales(it.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
 
         ctx.sr_repo.mark_void(sr_id, autocommit=False)

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -80,7 +80,7 @@ def reject_delivery_request(
     ctx: Context, actor: Actor, dr_id: int, reason: str
 ) -> tuple[int, DeliveryRequest]:
     if actor.role != Role.ADMIN:
-        raise Forbidden("only an ADMIN can reject a deliery request")
+        raise Forbidden("only an ADMIN can reject a delivery request")
 
     # reason obligatoire
     if reason is None or not str(reason).strip():

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -14,7 +14,7 @@ from policies.validations import (
 from .context import Context
 from .helpers import get_dr_or_raise, get_sr_or_raise
 from .errors import ValidationError
-from infra.errors import DataIntegrityError
+# from infra.errors import DataIntegrityError # leaving it there for now
 
 
 def create_delivery_request(
@@ -186,16 +186,12 @@ def void_sales_report(
         raise AlreadyVoided(f"sales report with id {sr_id} is already voided")
 
     try:
-        missing_items = [
-            it for it in sr.items
-            if ctx.pi_repo.get(sr.partner_id, it.book_id) is None
-        ]
-        if missing_items:
-            missing_book_ids = [it.book_id for it in missing_items]
-            raise DataIntegrityError(
-                f"Cannot void sales report {sr_id}: missing inventory lines for "
-                f"partner '{sr.partner_id}', books: {missing_book_ids}"
-            )
+        # data integrity error is a stretch we will ignore for now,
+        # but it could happen if, for example, the inventory line for a book in the report was deleted
+        # between the time we load the report and the time we try to restore quantity for that line
+        # the system does not allow deleting inventory lines
+        # the only way to manually create such a scenario would be to directly manipulate the database between retrieval and voiding,
+        # which is out of scope for this project goal
 
         for it in sr.items:
             pi = ctx.pi_repo.get(sr.partner_id, it.book_id)

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -14,6 +14,7 @@ from policies.validations import (
 from .context import Context
 from .helpers import get_dr_or_raise, get_sr_or_raise
 from .errors import ValidationError
+from infra.errors import DataIntegrityError
 
 
 def create_delivery_request(
@@ -185,10 +186,19 @@ def void_sales_report(
         raise AlreadyVoided(f"sales report with id {sr_id} is already voided")
 
     try:
+        missing_items = [
+            it for it in sr.items
+            if ctx.pi_repo.get(sr.partner_id, it.book_id) is None
+        ]
+        if missing_items:
+            missing_book_ids = [it.book_id for it in missing_items]
+            raise DataIntegrityError(
+                f"Cannot void sales report {sr_id}: missing inventory lines for "
+                f"partner '{sr.partner_id}', books: {missing_book_ids}"
+            )
+
         for it in sr.items:
             pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
-            if pi is None:
-                return sr_id, sr
             pi = pi.restore_sales(it.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
 

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 from domain.errors import InsufficientStock
 from domain.partner_inventory import PartnerInventory
 from domain.delivery_request import RequestItem, DeliveryRequest
@@ -19,8 +17,8 @@ from .errors import ValidationError
 
 
 def create_delivery_request(
-    ctx: Context, actor: Actor, payload: List[RequestItem]
-) -> Tuple[int, DeliveryRequest]:
+    ctx: Context, actor: Actor, payload: list[RequestItem]
+) -> tuple[int, DeliveryRequest]:
     if actor.role is not Role.PARTNER:
         raise Forbidden("only PARTNER can create a delivery request")
 
@@ -40,7 +38,7 @@ def create_delivery_request(
 
 def submit_delivery_request(
     ctx: Context, actor: Actor, dr_id: int
-) -> Tuple[int, DeliveryRequest]:
+) -> tuple[int, DeliveryRequest]:
     # AuthZ minimale (comme pour submit SR)
     if actor.role is not Role.PARTNER:
         raise Forbidden("only PARTNER can submit a delivery request")
@@ -66,7 +64,7 @@ def submit_delivery_request(
 
 def approve_delivery_request(
     ctx: Context, actor: Actor, dr_id: int
-) -> Tuple[int, DeliveryRequest]:
+) -> tuple[int, DeliveryRequest]:
     # AuthZ minimale (comme pour submit SR)
     if actor.role is not Role.ADMIN:
         raise Forbidden("only ADMIN can approve a delivery request")
@@ -79,7 +77,7 @@ def approve_delivery_request(
 
 def reject_delivery_request(
     ctx: Context, actor: Actor, dr_id: int, reason: str
-) -> Tuple[int, DeliveryRequest]:
+) -> tuple[int, DeliveryRequest]:
     if actor.role != Role.ADMIN:
         raise Forbidden("only an ADMIN can reject a deliery request")
 
@@ -114,7 +112,7 @@ def reject_delivery_request(
 
 def mark_delivered(
     ctx: Context, actor: Actor, dr_id: int
-) -> Tuple[int, DeliveryRequest]:
+) -> tuple[int, DeliveryRequest]:
     if actor.role is not Role.ADMIN:
         raise Forbidden("only ADMIN can mark a delivery request delivered")
 
@@ -138,8 +136,8 @@ def mark_delivered(
 
 
 def submit_sales_report(
-    ctx: Context, actor: Actor, payload: List[ReportItem]
-) -> Tuple[int, SalesReport]:
+    ctx: Context, actor: Actor, payload: list[ReportItem]
+) -> tuple[int, SalesReport]:
     # AuthZ minimale (rôles) : hors SR
     if actor.role != Role.PARTNER:
         raise Forbidden("only PARTNER can submit a sales report")
@@ -175,7 +173,7 @@ def submit_sales_report(
 
 def void_sales_report(
     ctx: Context, actor: Actor, sr_id: int, reason: str
-) -> Tuple[int, SalesReport]:
+) -> tuple[int, SalesReport]:
     if actor.role != Role.ADMIN:
         raise Forbidden("only an ADMIN can void a sales report")
 

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -1,5 +1,6 @@
 from typing import List, Tuple
 
+from domain.partner_inventory import PartnerInventory, InsufficientStock
 from domain.delivery_request import RequestItem, DeliveryRequest
 from domain.sales_report import AlreadyVoided, SalesReport, ReportItem
 from policies.identity import Forbidden, Role, Actor
@@ -10,7 +11,6 @@ from policies.active_delivery_request import (
 from policies.validations import (
     validate_report_items_in_catalog,
     validate_request_items_in_catalog,
-    validate_sales_report_against_stock,
 )
 from .context import Context
 from .helpers import get_dr_or_raise, get_sr_or_raise
@@ -112,6 +112,14 @@ def mark_delivered(
     dr = get_dr_or_raise(ctx, dr_id)
     dr.mark_delivered()
     ctx.dr_repo.save_status(dr_id, dr.status)
+    for items in dr.items:
+        pi = ctx.pi_repo.get(dr.partner_id, items.book_id)
+        if pi is None:
+            pi = PartnerInventory(
+                partner_id=dr.partner_id, book_sku=items.book_id, current_quantity=0
+            )
+        pi.deliver(items.quantity)
+        ctx.pi_repo.save(pi)
     return dr_id, dr
 
 
@@ -124,10 +132,25 @@ def submit_sales_report(
 
     report = SalesReport(partner_id=actor.partner_id, items=payload)  # invariants SR
     validate_report_items_in_catalog(report, ctx.catalog)  # policy externe
-    validate_sales_report_against_stock(
-        report=report, dr_repo=ctx.dr_repo, sr_repo=ctx.sr_repo
-    )
+    # validate_sales_report_against_stock(
+    #     report=report, dr_repo=ctx.dr_repo, sr_repo=ctx.sr_repo
+    # )
+    # update_report_quantities_against_stock(report, ctx.pi_repo)
+    working = {}
+    for it in report.items:
+        key = (report.partner_id, it.book_id)
+        if key not in working:
+            pi = ctx.pi_repo.get(report.partner_id, it.book_id)
+            if pi is None:
+                raise InsufficientStock(
+                    f"Cannot report sale of {it.quantity} for {it.book_id}, no copy available"
+                )
+            pi.reportSale(it.quantity)
+            working[key] = pi.clone()
+
     sr_id = ctx.sr_repo.create(report)  # persistance mémoire
+    for pi in working.values():
+        ctx.pi_repo.save(pi)
     return sr_id, report
 
 
@@ -143,6 +166,12 @@ def void_sales_report(
     sr = get_sr_or_raise(ctx, sr_id)
     if sr.voided:
         raise AlreadyVoided(f"sales report with id {sr_id} is already voided")
+
+    for it in sr.items:
+        pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
+        pi.restoreSales(it.quantity)
+        ctx.pi_repo.save(pi)
+
     ctx.sr_repo.mark_void(sr_id)
 
     ctx.audit.record(

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -58,7 +58,7 @@ def submit_delivery_request(
     )
 
     dr = dr.submit()
-    ctx.dr_repo.save_status(dr)
+    ctx.dr_repo.save(dr)
     return dr_id, dr
 
 
@@ -71,7 +71,7 @@ def approve_delivery_request(
 
     dr = get_dr_or_raise(ctx, dr_id)
     dr = dr.approve()
-    ctx.dr_repo.save_status(dr)
+    ctx.dr_repo.save(dr)
     return dr_id, dr
 
 
@@ -101,7 +101,7 @@ def reject_delivery_request(
 
         # Transition métier (idéalement: l'entité refuse si state != SUBMITTED)
         dr = dr.reject()
-        ctx.dr_repo.save_status(dr, autocommit=False)
+        ctx.dr_repo.save(dr, autocommit=False)
         ctx.dr_repo.conn.commit()
     except Exception:
         ctx.dr_repo.conn.rollback()
@@ -127,7 +127,7 @@ def mark_delivered(
                 )
             pi = pi.deliver(items.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
-        ctx.dr_repo.save_status(dr, autocommit=False)
+        ctx.dr_repo.save(dr, autocommit=False)
         ctx.dr_repo.conn.commit()
     except Exception:
         ctx.dr_repo.conn.rollback()

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -125,7 +125,7 @@ def mark_delivered(
                 pi = PartnerInventory(
                     partner_id=dr.partner_id, book_sku=items.book_id, current_quantity=0
                 )
-            pi.deliver(items.quantity)
+            pi = pi.deliver(items.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
         ctx.dr_repo.save_status(dr, autocommit=False)
         ctx.dr_repo.conn.commit()
@@ -156,7 +156,7 @@ def submit_sales_report(
                 raise InsufficientStock(
                     f"Cannot report sale of {it.quantity} for {it.book_id}, no copy available"
                 )
-            pi.reportSale(it.quantity)
+            pi = pi.reportSale(it.quantity)
             working[key] = pi  # .clone()
 
     try:
@@ -187,7 +187,7 @@ def void_sales_report(
     try:
         for it in sr.items:
             pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
-            pi.restoreSales(it.quantity)
+            pi = pi.restoreSales(it.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
 
         ctx.sr_repo.mark_void(sr_id, autocommit=False)

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -1,6 +1,7 @@
 from typing import List, Tuple
 
-from domain.partner_inventory import PartnerInventory, InsufficientStock
+from domain.errors import InsufficientStock
+from domain.partner_inventory import PartnerInventory
 from domain.delivery_request import RequestItem, DeliveryRequest
 from domain.sales_report import AlreadyVoided, SalesReport, ReportItem
 from policies.identity import Forbidden, Role, Actor
@@ -33,6 +34,7 @@ def create_delivery_request(
     validate_request_items_in_catalog(dr.items, ctx.catalog)
 
     dr_id = ctx.dr_repo.create(dr)
+    dr = get_dr_or_raise(ctx, dr_id)
     return dr_id, dr
 
 
@@ -57,8 +59,8 @@ def submit_delivery_request(
         partner_id=dr.partner_id, dr_repo=ctx.dr_repo, sr_repo=ctx.sr_repo
     )
 
-    dr.submit()
-    ctx.dr_repo.save_status(dr_id, dr.status)
+    dr = dr.submit()
+    ctx.dr_repo.save_status(dr)
     return dr_id, dr
 
 
@@ -70,8 +72,8 @@ def approve_delivery_request(
         raise Forbidden("only ADMIN can approve a delivery request")
 
     dr = get_dr_or_raise(ctx, dr_id)
-    dr.approve()
-    ctx.dr_repo.save_status(dr_id, dr.status)
+    dr = dr.approve()
+    ctx.dr_repo.save_status(dr)
     return dr_id, dr
 
 
@@ -100,8 +102,8 @@ def reject_delivery_request(
         )
 
         # Transition métier (idéalement: l'entité refuse si state != SUBMITTED)
-        dr.reject()
-        ctx.dr_repo.save_status(dr_id, dr.status, autocommit=False)
+        dr = dr.reject()
+        ctx.dr_repo.save_status(dr, autocommit=False)
         ctx.dr_repo.conn.commit()
     except Exception:
         ctx.dr_repo.conn.rollback()
@@ -118,7 +120,7 @@ def mark_delivered(
 
     try:
         dr = get_dr_or_raise(ctx, dr_id)
-        dr.mark_delivered()
+        dr = dr.mark_delivered()
         for items in dr.items:
             pi = ctx.pi_repo.get(dr.partner_id, items.book_id)
             if pi is None:
@@ -127,7 +129,7 @@ def mark_delivered(
                 )
             pi.deliver(items.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
-        ctx.dr_repo.save_status(dr_id, dr.status, autocommit=False)
+        ctx.dr_repo.save_status(dr, autocommit=False)
         ctx.dr_repo.conn.commit()
     except Exception:
         ctx.dr_repo.conn.rollback()

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -12,7 +12,7 @@ from policies.validations import (
     validate_request_items_in_catalog,
 )
 from .context import Context
-from .helpers import get_dr_or_raise, get_sr_or_raise
+from .helpers import get_dr_or_raise, get_sr_or_raise, restore_quantities_or_raise
 from .errors import ValidationError
 # from infra.errors import DataIntegrityError # leaving it there for now
 
@@ -186,18 +186,7 @@ def void_sales_report(
         raise AlreadyVoided(f"sales report with id {sr_id} is already voided")
 
     try:
-        # data integrity error is a stretch we will ignore for now,
-        # but it could happen if, for example, the inventory line for a book in the report was deleted
-        # between the time we load the report and the time we try to restore quantity for that line
-        # the system does not allow deleting inventory lines
-        # the only way to manually create such a scenario would be to directly manipulate the database between retrieval and voiding,
-        # which is out of scope for this project goal
-
-        for it in sr.items:
-            pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
-            pi = pi.restore_sales(it.quantity)
-            ctx.pi_repo.save(pi, autocommit=False)
-
+        restore_quantities_or_raise(ctx, sr, autocommit=False)
         ctx.sr_repo.mark_void(sr_id, autocommit=False)
         ctx.audit.record(
             {

--- a/app/use_cases.py
+++ b/app/use_cases.py
@@ -187,6 +187,8 @@ def void_sales_report(
     try:
         for it in sr.items:
             pi = ctx.pi_repo.get(sr.partner_id, it.book_id)
+            if pi is None:
+                return sr_id, sr
             pi = pi.restore_sales(it.quantity)
             ctx.pi_repo.save(pi, autocommit=False)
 

--- a/domain/delivery_request.py
+++ b/domain/delivery_request.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import List
 
 
 class InvalidDeliveryRequest(Exception):
@@ -33,13 +32,13 @@ class DeliveryRequest:
     id: int | None
     partner_id: str
     status: Status
-    items: List[RequestItem]
+    items: list[RequestItem]
 
     MIN_TOTAL_QUANTITY = 2
 
     @classmethod
     def save_draft(
-        cls, *, partner_id: str, items: List[RequestItem]
+        cls, *, partner_id: str, items: list[RequestItem]
     ) -> "DeliveryRequest":
         # DR non vide dès la création (selon ton choix)
         if not partner_id:

--- a/domain/delivery_request.py
+++ b/domain/delivery_request.py
@@ -1,7 +1,7 @@
 # delivery_request.py
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import List
 
@@ -28,8 +28,9 @@ class RequestItem:
     quantity: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class DeliveryRequest:
+    id: int | None
     partner_id: str
     status: Status
     items: List[RequestItem]
@@ -66,28 +67,30 @@ class DeliveryRequest:
                 f"request minimum size is {cls.MIN_TOTAL_QUANTITY} (current size: {total})"
             )
 
-        return cls(partner_id=partner_id, status=Status.DRAFT, items=list(items))
+        return cls(
+            id=None, partner_id=partner_id, status=Status.DRAFT, items=list(items)
+        )
 
-    def mark_delivered(self) -> None:
+    def mark_delivered(self) -> DeliveryRequest:
         # Invariant dominant: DELIVERED seulement si APPROVED
         if self.status is not Status.APPROVED:
             raise InvalidTransition("DELIVERED only if APPROVED")
-        self.status = Status.DELIVERED
+        return replace(self, status=Status.DELIVERED)
 
-    def approve(self) -> None:
+    def approve(self) -> DeliveryRequest:
         if self.status is not Status.SUBMITTED:
             raise InvalidTransition("APPROVED only if SUBMITTED")
-        self.status = Status.APPROVED
+        return replace(self, status=Status.APPROVED)
 
-    def submit(self) -> None:
+    def submit(self) -> DeliveryRequest:
         if self.status is not Status.DRAFT:
             raise InvalidTransition("SUBMITTED only if DRAFT")
-        self.status = Status.SUBMITTED
+        return replace(self, status=Status.SUBMITTED)
 
-    def reject(self) -> None:
+    def reject(self) -> DeliveryRequest:
         if self.status != Status.SUBMITTED:
             raise InvalidTransition("REJECTED only if SUBMITTED")
-        self.status = Status.REJECTED
+        return replace(self, status=Status.REJECTED)
 
     def __str__(self):
         return self.status

--- a/domain/delivery_request.py
+++ b/domain/delivery_request.py
@@ -91,5 +91,5 @@ class DeliveryRequest:
             raise InvalidTransition("REJECTED only if SUBMITTED")
         return replace(self, status=Status.REJECTED)
 
-    def __str__(self):
-        return self.status
+    # def __str__(self):
+    #     return self.status.value

--- a/domain/errors.py
+++ b/domain/errors.py
@@ -1,2 +1,12 @@
-class InvalidReport(Exception):
+class DomainError(Exception):
+    """Base class for domain errors"""
+
+    pass
+
+
+class InvalidReport(DomainError):
+    pass
+
+
+class InsufficientStock(DomainError):
     pass

--- a/domain/partner_inventory.py
+++ b/domain/partner_inventory.py
@@ -1,5 +1,4 @@
-class InsufficientStock(Exception):
-    pass
+from domain.errors import InsufficientStock
 
 
 class PartnerInventory:

--- a/domain/partner_inventory.py
+++ b/domain/partner_inventory.py
@@ -17,7 +17,7 @@ class PartnerInventory:
             version=self.version + 1,
         )
 
-    def reportSale(self, quantity: int):
+    def report_sale(self, quantity: int):
         if self.current_quantity < quantity:
             raise InsufficientStock(
                 f"Cannot report sale of {quantity} for {self.book_sku}, only {self.current_quantity} available"
@@ -28,7 +28,7 @@ class PartnerInventory:
             version=self.version + 1,
         )
 
-    def restoreSales(self, quantity: int):
+    def restore_sales(self, quantity: int):
         return replace(
             self,
             current_quantity=self.current_quantity + quantity,

--- a/domain/partner_inventory.py
+++ b/domain/partner_inventory.py
@@ -1,0 +1,36 @@
+class InsufficientStock(Exception):
+    pass
+
+
+class PartnerInventory:
+    def __init__(
+        self, partner_id: str, book_sku: str, current_quantity: int, version: int = 0
+    ):
+        self.partner_id = partner_id
+        self.book_sku = book_sku
+        self.current_quantity = current_quantity
+        self.version = version
+
+    def deliver(self, quantity: int):
+        self.current_quantity += quantity
+        self.version += 1
+
+    def reportSale(self, quantity: int):
+        if self.current_quantity < quantity:
+            raise InsufficientStock(
+                f"Cannot report sale of {quantity} for {self.book_sku}, only {self.current_quantity} available"
+            )
+        self.current_quantity -= quantity
+        self.version += 1
+
+    def restoreSales(self, quantity: int):
+        self.current_quantity += quantity
+        self.version += 1
+
+    def clone(self):
+        return PartnerInventory(
+            partner_id=self.partner_id,
+            book_sku=self.book_sku,
+            current_quantity=self.current_quantity,
+            version=self.version,
+        )

--- a/domain/partner_inventory.py
+++ b/domain/partner_inventory.py
@@ -1,30 +1,39 @@
+from dataclasses import dataclass, replace
+
 from domain.errors import InsufficientStock
 
 
+@dataclass(frozen=True)
 class PartnerInventory:
-    def __init__(
-        self, partner_id: str, book_sku: str, current_quantity: int, version: int = 0
-    ):
-        self.partner_id = partner_id
-        self.book_sku = book_sku
-        self.current_quantity = current_quantity
-        self.version = version
+    partner_id: str
+    book_sku: str
+    current_quantity: int
+    version: int = 0
 
     def deliver(self, quantity: int):
-        self.current_quantity += quantity
-        self.version += 1
+        return replace(
+            self,
+            current_quantity=self.current_quantity + quantity,
+            version=self.version + 1,
+        )
 
     def reportSale(self, quantity: int):
         if self.current_quantity < quantity:
             raise InsufficientStock(
                 f"Cannot report sale of {quantity} for {self.book_sku}, only {self.current_quantity} available"
             )
-        self.current_quantity -= quantity
-        self.version += 1
+        return replace(
+            self,
+            current_quantity=self.current_quantity - quantity,
+            version=self.version + 1,
+        )
 
     def restoreSales(self, quantity: int):
-        self.current_quantity += quantity
-        self.version += 1
+        return replace(
+            self,
+            current_quantity=self.current_quantity + quantity,
+            version=self.version + 1,
+        )
 
     def clone(self):
         return PartnerInventory(

--- a/domain/partner_inventory.py
+++ b/domain/partner_inventory.py
@@ -28,7 +28,7 @@ class PartnerInventory:
             version=self.version + 1,
         )
 
-    def restore_sales(self, quantity: int):
+    def restore_sale(self, quantity: int):
         return replace(
             self,
             current_quantity=self.current_quantity + quantity,

--- a/domain/sales_report.py
+++ b/domain/sales_report.py
@@ -26,7 +26,7 @@ class SalesReport:
             raise InvalidReport("partner_id is missing")
 
         if not self.items:
-            raise InvalidReport("report must contains at least one title")
+            raise InvalidReport("report must contain at least one title")
 
         total_quantity = 0
         books = set()

--- a/domain/sales_report.py
+++ b/domain/sales_report.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, replace
-from typing import List
 from .errors import InvalidReport
 
 
@@ -17,7 +16,7 @@ class ReportItem:
 class SalesReport:
     id: int | None
     partner_id: str
-    items: List[ReportItem]
+    items: list[ReportItem]
     voided: bool = False
 
     MIN_TOTAL_QUANTITY = 2

--- a/domain/sales_report.py
+++ b/domain/sales_report.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import List
 from .errors import InvalidReport
 
@@ -13,11 +13,14 @@ class ReportItem:
     quantity: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class SalesReport:
+    id: int | None
     partner_id: str
     items: List[ReportItem]
     voided: bool = False
+
+    MIN_TOTAL_QUANTITY = 2
 
     def __post_init__(self) -> None:
         if not self.partner_id:
@@ -26,7 +29,7 @@ class SalesReport:
         if not self.items:
             raise InvalidReport("report must contains at least one title")
 
-        total_quantity, min_size = 0, 2
+        total_quantity = 0
         books = set()
 
         for it in self.items:
@@ -42,12 +45,12 @@ class SalesReport:
                 raise InvalidReport("quantity must be positive")
             total_quantity += it.quantity
 
-        if total_quantity < min_size:
+        if total_quantity < self.MIN_TOTAL_QUANTITY:
             raise InvalidReport(
-                f"report minimum size is {min_size} (current size: {total_quantity})"
+                f"report minimum size is {self.MIN_TOTAL_QUANTITY} (current size: {total_quantity})"
             )
 
     def void(self):
         if self.voided:
             raise AlreadyVoided("report is already voided")
-        self.voided = True
+        return replace(self, voided=True)

--- a/infra/errors.py
+++ b/infra/errors.py
@@ -1,0 +1,4 @@
+class DataIntegrityError(Exception):
+    """Raised when a data consistency violation is detected at the infrastructure level."""
+
+    pass

--- a/infra/sql/schema.sql
+++ b/infra/sql/schema.sql
@@ -42,3 +42,14 @@ CREATE TABLE audit_events (
     reason TEXT,
     created_at TEXT NOT NULL
 );
+
+CREATE TABLE partner_inventories (
+    book_sku TEXT NOT NULL,
+    partner_id TEXT NOT NULL,
+    current_quantity INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    PRIMARY KEY (book_sku, partner_id),
+    CHECK (current_quantity >= 0),
+    CHECK (version >= 0),
+    CHECK (partner_id IN ('p1', 'p2', 'luigi', 'mario', 'peach', 'yoshi'))
+)

--- a/infra/sql/schema.sql
+++ b/infra/sql/schema.sql
@@ -52,4 +52,4 @@ CREATE TABLE partner_inventories (
     CHECK (current_quantity >= 0),
     CHECK (version >= 0),
     CHECK (partner_id IN ('p1', 'p2', 'luigi', 'mario', 'peach', 'yoshi'))
-)
+);

--- a/infra/sql/sql_audit_repo.py
+++ b/infra/sql/sql_audit_repo.py
@@ -9,7 +9,7 @@ class SqlAuditRepo:
     def __init__(self, conn):
         self.conn = conn
 
-    def record(self, event: dict) -> int:
+    def record(self, event: dict, autocommit=True) -> int:
         event_type = event["type"]
         reason = event.get("reason")
 
@@ -42,7 +42,8 @@ class SqlAuditRepo:
                 datetime.now(timezone.utc).isoformat(),
             ),
         )
-        self.conn.commit()
+        if autocommit:
+            self.conn.commit()
         return cur.lastrowid
 
     def get(self, event_id: int) -> dict | None:

--- a/infra/sql/sql_delivery_request_repo.py
+++ b/infra/sql/sql_delivery_request_repo.py
@@ -67,7 +67,7 @@ class SqlDeliveryRequestRepo:
             items=items,
         )
 
-    def save_status(self, dr: DeliveryRequest, autocommit: bool = True) -> int:
+    def save(self, dr: DeliveryRequest, autocommit: bool = True) -> int:
         cur = self.conn.cursor()
         cur.execute(
             """

--- a/infra/sql/sql_delivery_request_repo.py
+++ b/infra/sql/sql_delivery_request_repo.py
@@ -70,7 +70,9 @@ class SqlDeliveryRequestRepo:
             items=items,
         )
 
-    def save_status(self, dr_id: int, status: DRStatus) -> int | None:
+    def save_status(
+        self, dr_id: int, status: DRStatus, autocommit: bool = True
+    ) -> int | None:
         cur = self.conn.cursor()
 
         # dr = self.get(dr_id)
@@ -86,5 +88,6 @@ class SqlDeliveryRequestRepo:
             (status, dr_id),
         )
 
-        self.conn.commit()
+        if autocommit:
+            self.conn.commit()
         return dr_id

--- a/infra/sql/sql_delivery_request_repo.py
+++ b/infra/sql/sql_delivery_request_repo.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from app.errors import NotFound
 from domain.delivery_request import DeliveryRequest, RequestItem, Status as DRStatus
 
 
@@ -19,7 +18,6 @@ class SqlDeliveryRequestRepo:
         )
 
         dr_id = cur.lastrowid
-        # dr.id = dr_id
 
         for item in dr.items:
             book_sku = item.book_id
@@ -41,7 +39,7 @@ class SqlDeliveryRequestRepo:
 
         row = cur.execute(
             """
-            SELECT id, partner_id, status, created_at
+            SELECT id, partner_id, status
             FROM delivery_requests
             WHERE id = ?
             """,
@@ -49,7 +47,7 @@ class SqlDeliveryRequestRepo:
         ).fetchone()
 
         if row is None:
-            return
+            return None
 
         items_rows = cur.execute(
             """
@@ -63,31 +61,23 @@ class SqlDeliveryRequestRepo:
         items = [RequestItem(sku, qty) for sku, qty in items_rows]
 
         return DeliveryRequest(
-            # id=row[0],
+            id=row[0],
             partner_id=row[1],
             status=DRStatus(row[2]),
-            # created_at=row[3],
             items=items,
         )
 
-    def save_status(
-        self, dr_id: int, status: DRStatus, autocommit: bool = True
-    ) -> int | None:
+    def save_status(self, dr: DeliveryRequest, autocommit: bool = True) -> int:
         cur = self.conn.cursor()
-
-        # dr = self.get(dr_id)
-        # if dr is None:
-        #     return None
-
         cur.execute(
             """
             UPDATE delivery_requests
             SET status = ?
             WHERE id = ?
             """,
-            (status, dr_id),
+            (dr.status.value, dr.id),
         )
 
         if autocommit:
             self.conn.commit()
-        return dr_id
+        return dr.id

--- a/infra/sql/sql_partner_inventory_repo.py
+++ b/infra/sql/sql_partner_inventory_repo.py
@@ -1,0 +1,46 @@
+from domain.partner_inventory import PartnerInventory
+
+
+class SqlPartnerInventoryRepo:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def save(self, partner_inventory):
+        cur = self.conn.cursor()
+        # pi = self.get(partner_inventory.partner_id, partner_inventory.book_sku)
+
+        cur.execute(
+            """
+            INSERT INTO partner_inventories (partner_id, book_sku, current_quantity, version)
+            VALUES (?, ?, ?, ?) ON CONFLICT (partner_id, book_sku) DO UPDATE
+            SET current_quantity = excluded.current_quantity, version = excluded.version
+        """,
+            (
+                partner_inventory.partner_id,
+                partner_inventory.book_sku,
+                partner_inventory.current_quantity,
+                partner_inventory.version,
+            ),
+        )
+        self.conn.commit()
+
+    def get(self, partner_id, book_sku):
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            SELECT partner_id, book_sku, current_quantity, version
+            FROM partner_inventories
+            WHERE partner_id = ? AND book_sku = ?
+        """,
+            (partner_id, book_sku),
+        )
+        row = cur.fetchone()
+        if row:
+            return PartnerInventory(
+                partner_id=row[0],
+                book_sku=row[1],
+                current_quantity=row[2],
+                version=row[3],
+            )
+        else:
+            return None

--- a/infra/sql/sql_partner_inventory_repo.py
+++ b/infra/sql/sql_partner_inventory_repo.py
@@ -5,7 +5,7 @@ class SqlPartnerInventoryRepo:
     def __init__(self, conn):
         self.conn = conn
 
-    def save(self, partner_inventory):
+    def save(self, partner_inventory, autocommit=True):
         cur = self.conn.cursor()
         # pi = self.get(partner_inventory.partner_id, partner_inventory.book_sku)
 
@@ -22,7 +22,8 @@ class SqlPartnerInventoryRepo:
                 partner_inventory.version,
             ),
         )
-        self.conn.commit()
+        if autocommit:
+            self.conn.commit()
 
     def get(self, partner_id, book_sku):
         cur = self.conn.cursor()

--- a/infra/sql/sql_partner_inventory_repo.py
+++ b/infra/sql/sql_partner_inventory_repo.py
@@ -12,7 +12,7 @@ class SqlPartnerInventoryRepo:
         cur.execute(
             """
             INSERT INTO partner_inventories (partner_id, book_sku, current_quantity, version)
-            VALUES (?, ?, ?, ?) ON CONFLICT (partner_id, book_sku) DO UPDATE
+            VALUES (?, ?, ?, ?) ON CONFLICT (book_sku, partner_id) DO UPDATE
             SET current_quantity = excluded.current_quantity, version = excluded.version
         """,
             (

--- a/infra/sql/sql_sales_report_repo.py
+++ b/infra/sql/sql_sales_report_repo.py
@@ -60,6 +60,7 @@ class SqlSalesReportRepo:
         items = [ReportItem(book_id=r[0], quantity=r[1]) for r in items_rows]
 
         return SalesReport(
+            id=row[0],
             partner_id=row[1],
             voided=bool(row[2]),
             items=items,

--- a/infra/sql/sql_sales_report_repo.py
+++ b/infra/sql/sql_sales_report_repo.py
@@ -6,7 +6,7 @@ class SqlSalesReportRepo:
     def __init__(self, conn):
         self.conn = conn
 
-    def create(self, report: SalesReport) -> int:
+    def create(self, report: SalesReport, autocommit=True) -> int:
         cur = self.conn.cursor()
         is_voided = 1 if report.voided else 0
 
@@ -29,7 +29,8 @@ class SqlSalesReportRepo:
                 (report_id, item.book_id, item.quantity),
             )
 
-        self.conn.commit()
+        if autocommit:
+            self.conn.commit()
         return report_id
 
     def get(self, report_id: int) -> SalesReport | None:
@@ -64,7 +65,7 @@ class SqlSalesReportRepo:
             items=items,
         )
 
-    def mark_void(self, report_id: int) -> int | None:
+    def mark_void(self, report_id: int, autocommit=True) -> int | None:
         cur = self.conn.cursor()
 
         cur.execute(
@@ -75,6 +76,6 @@ class SqlSalesReportRepo:
             """,
             (report_id,),
         )
-
-        self.conn.commit()
+        if autocommit:
+            self.conn.commit()
         return report_id

--- a/policies/report_required.py
+++ b/policies/report_required.py
@@ -1,6 +1,5 @@
 # report_required.py
 from __future__ import annotations
-from typing import Optional
 
 
 from infra.sql.sql_delivery_request_repo import SqlDeliveryRequestRepo
@@ -35,7 +34,7 @@ def ensure_report_submitted_since_last_delivery(
         (partner_id,),
     )
     last_delivered_row = cur.fetchone()
-    last_delivered_seq: Optional[int] = None
+    last_delivered_seq: int | None = None
     if last_delivered_row:
         last_delivered_seq = last_delivered_row[0]
 

--- a/policies/stock_projection.py
+++ b/policies/stock_projection.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from infra.sql.sql_delivery_request_repo import SqlDeliveryRequestRepo
 from infra.sql.sql_sales_report_repo import SqlSalesReportRepo
 
@@ -8,7 +6,7 @@ def compute_partner_stock(
     partner_id: str,
     dr_repo: SqlDeliveryRequestRepo,
     sr_repo: SqlSalesReportRepo,
-) -> Dict[str, int]:
+) -> dict[str, int]:
     cur = dr_repo.conn.cursor()
 
     delivered_rows = cur.execute(

--- a/policies/validations.py
+++ b/policies/validations.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Set
+from typing import Iterable
 from domain.delivery_request import (
     RequestItem,
     InvalidDeliveryRequest,
@@ -17,10 +17,10 @@ def validate_report_items_in_catalog(report: SalesReport, catalog: Iterable[str]
 
 
 def validate_request_items_in_catalog(
-    items: List[RequestItem],
+    items: list[RequestItem],
     catalog: Iterable[str],
 ) -> None:
-    catalog_set: Set[str] = set(catalog)
+    catalog_set: set[str] = set(catalog)
     unknown = [it.book_id for it in items if it.book_id not in catalog_set]
     if unknown:
         raise InvalidDeliveryRequest(f"Unknown book_id(s): {', '.join(unknown)}")

--- a/policies/validations.py
+++ b/policies/validations.py
@@ -5,14 +5,6 @@ from domain.delivery_request import (
 )
 from domain.sales_report import SalesReport
 from domain.errors import InvalidReport
-from app.repositories import InMemoryDeliveryRequestRepo, InMemorySalesReportRepo
-from infra.sql.sql_delivery_request_repo import SqlDeliveryRequestRepo
-from infra.sql.sql_sales_report_repo import SqlSalesReportRepo
-from .stock_projection import compute_partner_stock
-
-
-class InsufficientStock(Exception):
-    pass
 
 
 def validate_report_items_in_catalog(report: SalesReport, catalog: Iterable[str]):
@@ -32,27 +24,3 @@ def validate_request_items_in_catalog(
     unknown = [it.book_id for it in items if it.book_id not in catalog_set]
     if unknown:
         raise InvalidDeliveryRequest(f"Unknown book_id(s): {', '.join(unknown)}")
-
-
-def validate_sales_report_against_stock(
-    *,
-    report: SalesReport,
-    dr_repo: SqlDeliveryRequestRepo,
-    sr_repo: SqlSalesReportRepo,
-) -> None:
-    """
-    Stock entrant (par book_id) = somme des DR DELIVERED pour ce partner.
-    Stock sortant = somme des SR déjà soumis (persistés) pour ce partner.
-    Règle: sortant_existant + sortant_nouveau <= entrant, pour chaque book_id du report.
-    """
-    stock = compute_partner_stock(report.partner_id, dr_repo=dr_repo, sr_repo=sr_repo)
-    violations = []
-    for it in report.items:
-        available = stock.get(it.book_id, 0)
-        if it.quantity > available:
-            violations.append(
-                f"{it.book_id} (reported {it.quantity}, available {available})"
-            )
-
-    if violations:
-        raise InsufficientStock("Insufficient stock for: " + ", ".join(violations))

--- a/runner/dispatch.py
+++ b/runner/dispatch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from app.context import Context
-from app.helpers import get_dr_or_raise
+from app.queries import get_partner_inventory
 from app.use_cases import (
     approve_delivery_request,
     create_delivery_request,
@@ -17,7 +17,6 @@ from app.use_cases import (
 from domain.delivery_request import RequestItem
 from domain.sales_report import ReportItem
 from policies.identity import Actor
-from policies.stock_projection import compute_partner_stock
 from runner.parser import ParsedLine
 
 
@@ -100,11 +99,7 @@ def run_show(runtime: RunnerRuntime, parsed: ParsedLine) -> RunnerResult:
 
 
 def run_stock(runtime: RunnerRuntime, parsed: ParsedLine) -> RunnerResult:
-    stock = compute_partner_stock(
-        runtime.partner_id,
-        runtime.ctx.dr_repo,
-        runtime.ctx.sr_repo,
-    )
+    stock = get_partner_inventory(runtime.partner_id, runtime.ctx.pi_repo)
     if not stock:
         return _ok(None, f"stock {runtime.partner_id}: empty")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from app.context import Context
 from infra.sql.sql_audit_repo import SqlAuditRepo
 from infra.sql.sql_delivery_request_repo import SqlDeliveryRequestRepo
+from infra.sql.sql_partner_inventory_repo import SqlPartnerInventoryRepo
 from infra.sql.sql_sales_report_repo import SqlSalesReportRepo
 from domain.delivery_request import DeliveryRequest, Status as DRStatus
 from domain.sales_report import SalesReport
@@ -101,7 +102,9 @@ def sr_repo(conn) -> TestSqlSalesReportRepo:
 
 @pytest.fixture
 def ctx(catalog, conn, dr_repo, sr_repo) -> Context:
-    return Context(catalog, dr_repo, sr_repo, SqlAuditRepo(conn))
+    return Context(
+        catalog, dr_repo, sr_repo, SqlPartnerInventoryRepo(conn), SqlAuditRepo(conn)
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,8 @@ class TestSqlDeliveryRequestRepo(SqlDeliveryRequestRepo):
         ]
         return [(dr_id, self.get(dr_id)) for dr_id in ids]
 
-    def save_status(self, dr_id: int, status: DRStatus) -> int | None:
-        return super().save_status(dr_id, status.value)
+    def save_status(self, dr: DeliveryRequest, autocommit: bool = True) -> int:
+        return super().save_status(dr, autocommit)
 
 
 class TestSqlSalesReportRepo(SqlSalesReportRepo):
@@ -101,9 +101,23 @@ def sr_repo(conn) -> TestSqlSalesReportRepo:
 
 
 @pytest.fixture
-def ctx(catalog, conn, dr_repo, sr_repo) -> Context:
+def pi_repo(conn) -> SqlPartnerInventoryRepo:
+    return SqlPartnerInventoryRepo(conn)
+
+
+@pytest.fixture
+def audit_repo(conn) -> SqlAuditRepo:
+    return SqlAuditRepo(conn)
+
+
+@pytest.fixture
+def ctx(catalog, dr_repo, sr_repo, pi_repo, audit_repo) -> Context:
     return Context(
-        catalog, dr_repo, sr_repo, SqlPartnerInventoryRepo(conn), SqlAuditRepo(conn)
+        catalog,
+        dr_repo,
+        sr_repo,
+        pi_repo,
+        audit_repo,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,8 @@ class TestSqlDeliveryRequestRepo(SqlDeliveryRequestRepo):
         ]
         return [(dr_id, self.get(dr_id)) for dr_id in ids]
 
-    def save_status(self, dr: DeliveryRequest, autocommit: bool = True) -> int:
-        return super().save_status(dr, autocommit)
+    def save(self, dr: DeliveryRequest, autocommit: bool = True) -> int:
+        return super().save(dr, autocommit)
 
 
 class TestSqlSalesReportRepo(SqlSalesReportRepo):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,7 @@ from app.use_cases import (
     submit_sales_report,
 )
 from domain.delivery_request import DeliveryRequest, RequestItem, Status as DRStatus
-from domain.sales_report import SalesReport, ReportItem
+from domain.sales_report import ReportItem
 from policies.identity import Actor, Role
 
 
@@ -25,6 +25,12 @@ def default_items() -> List[RequestItem]:
     return [
         RequestItem(book_id="b1", quantity=2),
         RequestItem(book_id="b2", quantity=3),
+    ]
+
+
+def default_sales() -> List[ReportItem]:
+    return [
+        ReportItem(book_id="b2", quantity=2),
     ]
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -63,10 +63,12 @@ def given_dr(ctx, partner_id: str, status: DRStatus, items=None) -> int:
     return dr_id
 
 
-def given_sr(ctx, partner_id: str, items: list[ReportItem] = [], voided=False) -> int:
-    if not items:
+def given_sr(
+    ctx, partner_id: str, items: list[ReportItem] | None = None, voided: bool = False
+) -> int:
+    if items is None:
         items = default_sales()
     sr_id, _ = submit_sales_report(ctx, partner_actor(partner_id), items)
     if voided:
-        ctx.sr_repo.void(sr_id)
+        ctx.sr_repo.mark_void(sr_id)
     return sr_id

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,12 @@
 from typing import List
 
+from app.use_cases import (
+    approve_delivery_request,
+    mark_delivered,
+    reject_delivery_request,
+    submit_delivery_request,
+    submit_sales_report,
+)
 from domain.delivery_request import DeliveryRequest, RequestItem, Status as DRStatus
 from domain.sales_report import SalesReport, ReportItem
 from policies.identity import Actor, Role
@@ -34,27 +41,28 @@ def given_dr(ctx, partner_id: str, status: DRStatus, items=None) -> int:
     dr = ctx.dr_repo.get(dr_id)
 
     if status == DRStatus.SUBMITTED:
-        dr.submit()
+        _, dr = submit_delivery_request(ctx, partner_actor(partner_id), dr_id)
 
     elif status == DRStatus.APPROVED:
-        dr.submit()
-        dr.approve()
+        _, dr = submit_delivery_request(ctx, partner_actor(partner_id), dr_id)
+        _, dr = approve_delivery_request(ctx, admin_actor(), dr_id)
 
     elif status == DRStatus.REJECTED:
-        dr.submit()
-        dr.reject()
+        _, dr = submit_delivery_request(ctx, partner_actor(partner_id), dr_id)
+        _, dr = reject_delivery_request(ctx, admin_actor(), dr_id, reason="test reason")
 
     elif status == DRStatus.DELIVERED:
-        dr.submit()
-        dr.approve()
-        dr.mark_delivered()
+        _, dr = submit_delivery_request(ctx, partner_actor(partner_id), dr_id)
+        _, dr = approve_delivery_request(ctx, admin_actor(), dr_id)
+        _, dr = mark_delivered(ctx, admin_actor(), dr_id)
 
-    ctx.dr_repo.save_status(dr_id, dr.status)
     return dr_id
 
 
 def given_sr(
     ctx, partner_id: str, items=[ReportItem(book_id="b2", quantity=2)], voided=False
 ) -> int:
-    sr = SalesReport(partner_id=partner_id, items=items, voided=voided)
-    return ctx.sr_repo.create(sr)
+    sr_id, _ = submit_sales_report(ctx, partner_actor(partner_id), items)
+    if voided:
+        ctx.sr_repo.void(sr_id)
+    return sr_id

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from app.use_cases import (
     approve_delivery_request,
     mark_delivered,
@@ -20,7 +18,7 @@ def admin_actor():
     return Actor(role=Role.ADMIN, partner_id=None)
 
 
-def default_items() -> List[RequestItem]:
+def default_items() -> list[RequestItem]:
     # respecte MinimumCopies = 2
     return [
         RequestItem(book_id="b1", quantity=2),
@@ -28,7 +26,7 @@ def default_items() -> List[RequestItem]:
     ]
 
 
-def default_sales() -> List[ReportItem]:
+def default_sales() -> list[ReportItem]:
     return [
         ReportItem(book_id="b2", quantity=2),
     ]
@@ -65,9 +63,9 @@ def given_dr(ctx, partner_id: str, status: DRStatus, items=None) -> int:
     return dr_id
 
 
-def given_sr(
-    ctx, partner_id: str, items=[ReportItem(book_id="b2", quantity=2)], voided=False
-) -> int:
+def given_sr(ctx, partner_id: str, items: list[ReportItem] = [], voided=False) -> int:
+    if not items:
+        items = default_sales()
     sr_id, _ = submit_sales_report(ctx, partner_actor(partner_id), items)
     if voided:
         ctx.sr_repo.void(sr_id)

--- a/tests/test_delivery_request.py
+++ b/tests/test_delivery_request.py
@@ -1,6 +1,13 @@
 import pytest
 
-from domain.delivery_request import DeliveryRequest, RequestItem, InvalidTransition, Status, InvalidDeliveryRequest
+from domain.delivery_request import (
+    DeliveryRequest,
+    RequestItem,
+    InvalidTransition,
+    Status,
+    InvalidDeliveryRequest,
+)
+
 
 @pytest.mark.parametrize(
     "start_status",
@@ -12,36 +19,47 @@ from domain.delivery_request import DeliveryRequest, RequestItem, InvalidTransit
     ],
 )
 def test_mark_delivered_allowed_only_from_approved(start_status):
-  dr = make_dr(start_status)
-  with pytest.raises(InvalidTransition, match="only if APPROVED"):
-    dr.mark_delivered()
+    dr = make_dr(start_status)
+    with pytest.raises(InvalidTransition, match="only if APPROVED"):
+        dr.mark_delivered()
+
 
 def test_mark_delivered_transitions_approved_to_delivered():
-  dr = make_dr(Status.APPROVED)
-  dr.mark_delivered()
-  assert dr.status == Status.DELIVERED
+    dr = make_dr(Status.APPROVED)
+    dr = dr.mark_delivered()
+    assert dr.status == Status.DELIVERED
 
-@pytest.mark.parametrize("start_status", [Status.DRAFT, Status.APPROVED, Status.DELIVERED, Status.REJECTED])
+
+@pytest.mark.parametrize(
+    "start_status", [Status.DRAFT, Status.APPROVED, Status.DELIVERED, Status.REJECTED]
+)
 def test_approve_allowed_only_from_submitted(start_status):
-  dr = make_dr(start_status)
-  with pytest.raises(InvalidTransition, match=r"only if SUBMITTED"):
-    dr.approve()
+    dr = make_dr(start_status)
+    with pytest.raises(InvalidTransition, match=r"only if SUBMITTED"):
+        dr.approve()
+
 
 def test_approve_transitions_submitted_to_approved():
-  dr = make_dr(Status.SUBMITTED)
-  dr.approve()
-  assert dr.status == Status.APPROVED
+    dr = make_dr(Status.SUBMITTED)
+    dr = dr.approve()
+    assert dr.status == Status.APPROVED
 
-@pytest.mark.parametrize("start_status", [Status.SUBMITTED, Status.APPROVED, Status.DELIVERED, Status.REJECTED])
+
+@pytest.mark.parametrize(
+    "start_status",
+    [Status.SUBMITTED, Status.APPROVED, Status.DELIVERED, Status.REJECTED],
+)
 def test_submit_allowed_only_from_draft(start_status):
-  dr = make_dr(start_status)
-  with pytest.raises(InvalidTransition, match=r"only if DRAFT"):
-    dr.submit()
+    dr = make_dr(start_status)
+    with pytest.raises(InvalidTransition, match=r"only if DRAFT"):
+        dr.submit()
+
 
 def test_submit_transitions_draft_to_submitted():
-  dr = make_dr(Status.DRAFT)
-  dr.submit()
-  assert dr.status == Status.SUBMITTED
+    dr = make_dr(Status.DRAFT)
+    dr = dr.submit()
+    assert dr.status == Status.SUBMITTED
+
 
 def test_save_draft_requires_partner_id():
     with pytest.raises(InvalidDeliveryRequest, match=r"partner_id is missing"):
@@ -50,12 +68,14 @@ def test_save_draft_requires_partner_id():
             items=[RequestItem("b1", 2)],
         )
 
+
 def test_save_draft_requires_at_least_one_item():
     with pytest.raises(InvalidDeliveryRequest, match=r"at least one title"):
         DeliveryRequest.save_draft(
             partner_id="p1",
             items=[],
         )
+
 
 def test_save_draft_requires_all_item_book_ids_present():
     with pytest.raises(InvalidDeliveryRequest, match=r"book_id is required"):
@@ -64,12 +84,14 @@ def test_save_draft_requires_all_item_book_ids_present():
             items=[RequestItem("", 1)],
         )
 
+
 def test_save_draft_rejects_duplicate_book_ids():
     with pytest.raises(InvalidDeliveryRequest, match=r"duplicate book_id"):
         DeliveryRequest.save_draft(
             partner_id="p1",
             items=[RequestItem("b1", 1), RequestItem("b1", 2)],
         )
+
 
 def test_save_draft_requires_positive_quantities():
     with pytest.raises(InvalidDeliveryRequest, match=r"quantity must be positive"):
@@ -78,6 +100,7 @@ def test_save_draft_requires_positive_quantities():
             items=[RequestItem("b1", 0)],
         )
 
+
 def test_save_draft_requires_min_total_copies():
     # On met exprès une taille "trop petite". Ajuste selon MIN_TOTAL_QUANTITY si besoin.
     with pytest.raises(InvalidDeliveryRequest, match=r"request minimum size is"):
@@ -85,6 +108,7 @@ def test_save_draft_requires_min_total_copies():
             partner_id="p1",
             items=[RequestItem("b1", 1)],
         )
+
 
 def test_save_draft_happy_path():
     dr = DeliveryRequest.save_draft(
@@ -98,5 +122,8 @@ def test_save_draft_happy_path():
 
 """ Helpers """
 
+
 def make_dr(status: Status) -> DeliveryRequest:
-    return DeliveryRequest(partner_id="p1", status=status, items=[RequestItem("b1", 2)])
+    return DeliveryRequest(
+        id=1, partner_id="p1", status=status, items=[RequestItem("b1", 2)]
+    )

--- a/tests/test_partner_inventory.py
+++ b/tests/test_partner_inventory.py
@@ -1,7 +1,8 @@
 import pytest
 
 from app.use_cases import submit_sales_report, void_sales_report
-from domain.partner_inventory import InsufficientStock, PartnerInventory
+from domain.partner_inventory import PartnerInventory
+from domain.errors import InsufficientStock
 from domain.sales_report import ReportItem
 
 
@@ -9,7 +10,7 @@ def test_report_decreases_inventory_and_raises_if_insufficient(ctx):
     pi = PartnerInventory(partner_id="p1", book_sku="b1", current_quantity=10)
     ctx.pi_repo.save(pi)
 
-    pi = pi.reportSale(4)
+    pi = pi.report_sale(4)
     ctx.pi_repo.save(pi)
 
     updated_pi = ctx.pi_repo.get("p1", "b1")
@@ -17,7 +18,7 @@ def test_report_decreases_inventory_and_raises_if_insufficient(ctx):
 
     # reporting more than available should raise
     with pytest.raises(InsufficientStock):
-        pi.reportSale(7)
+        pi = pi.report_sale(7)
 
 
 def test_multiple_lines_atomicity(ctx, partner_actor):

--- a/tests/test_partner_inventory.py
+++ b/tests/test_partner_inventory.py
@@ -1,0 +1,61 @@
+import pytest
+
+from app.use_cases import submit_sales_report, void_sales_report
+from domain.partner_inventory import InsufficientStock, PartnerInventory
+from domain.sales_report import ReportItem
+
+
+def test_report_decreases_inventory_and_raises_if_insufficient(ctx):
+    pi = PartnerInventory(partner_id="p1", book_sku="b1", current_quantity=10)
+    ctx.pi_repo.save(pi)
+
+    pi = pi.reportSale(4)
+    ctx.pi_repo.save(pi)
+
+    updated_pi = ctx.pi_repo.get("p1", "b1")
+    assert updated_pi.current_quantity == 6
+
+    # reporting more than available should raise
+    with pytest.raises(InsufficientStock):
+        pi.reportSale(7)
+
+
+def test_multiple_lines_atomicity(ctx, partner_actor):
+    pi = PartnerInventory(
+        partner_id=partner_actor.partner_id, book_sku="b1", current_quantity=10
+    )
+    ctx.pi_repo.save(pi)
+    pi = PartnerInventory(
+        partner_id=partner_actor.partner_id, book_sku="b2", current_quantity=5
+    )
+    ctx.pi_repo.save(pi)
+
+    items = [ReportItem(book_id="b1", quantity=4), ReportItem(book_id="b2", quantity=6)]
+    with pytest.raises(InsufficientStock):
+        submit_sales_report(ctx, partner_actor, items)
+
+    updated_pi = ctx.pi_repo.get(partner_actor.partner_id, "b1")
+    assert updated_pi.current_quantity == 10  # inventory should remain unchanged
+    updated_pi = ctx.pi_repo.get(partner_actor.partner_id, "b2")
+    assert updated_pi.current_quantity == 5  # inventory should remain unchanged
+
+
+def test_void_sales_report_restores_inventory(ctx, partner_actor, admin_actor):
+    pi = PartnerInventory(partner_id="p1", book_sku="b1", current_quantity=10)
+    ctx.pi_repo.save(pi)
+
+    report_id, report = submit_sales_report(
+        ctx, partner_actor, [ReportItem(book_id="b1", quantity=4)]
+    )
+
+    assert (
+        ctx.pi_repo.get("p1", "b1").current_quantity == 6
+    )  # inventory should be decreased
+
+    # Simulate reporting the sale (without actually updating inventory in this test)
+    # and then voiding the sales report
+    void_sales_report(ctx, admin_actor, report_id, reason="test void")
+
+    # After voiding, the inventory should be restored
+    updated_pi = ctx.pi_repo.get("p1", "b1")
+    assert updated_pi.current_quantity == 10  # inventory should be restored

--- a/tests/test_partner_inventory.py
+++ b/tests/test_partner_inventory.py
@@ -45,18 +45,15 @@ def test_void_sales_report_restores_inventory(ctx, partner_actor, admin_actor):
     pi = PartnerInventory(partner_id="p1", book_sku="b1", current_quantity=10)
     ctx.pi_repo.save(pi)
 
-    report_id, report = submit_sales_report(
+    report_id, _ = submit_sales_report(
         ctx, partner_actor, [ReportItem(book_id="b1", quantity=4)]
     )
 
     assert (
         ctx.pi_repo.get("p1", "b1").current_quantity == 6
-    )  # inventory should be decreased
-
-    # Simulate reporting the sale (without actually updating inventory in this test)
-    # and then voiding the sales report
+    )  # inventory should be decreased after submitting the sales report
     void_sales_report(ctx, admin_actor, report_id, reason="test void")
 
-    # After voiding, the inventory should be restored
+    # Void the previously submitted sales report, which should restore inventory
     updated_pi = ctx.pi_repo.get("p1", "b1")
-    assert updated_pi.current_quantity == 10  # inventory should be restored
+    assert updated_pi.current_quantity == 10

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -114,13 +114,13 @@ def test_compute_partner_stock_ignores_other_partners(ctx):
 
 def test_compute_partner_stock_ignores_voided_sales(ctx, admin_actor, partner_actor):
     _ = given_dr(ctx, partner_actor.partner_id, DRStatus.DELIVERED)
-    _ = given_sr(ctx, partner_actor.partner_id)
+    sr_id = given_sr(ctx, partner_actor.partner_id)
     stock_before_void = compute_partner_stock(
         partner_actor.partner_id, ctx.dr_repo, ctx.sr_repo
     )
     assert stock_before_void == {"b1": 2, "b2": 1}
 
-    void_sales_report(ctx, admin_actor, 1, reason="test void")
+    void_sales_report(ctx, admin_actor, sr_id, reason="test void")
     stock_after_void = compute_partner_stock(
         partner_actor.partner_id, ctx.dr_repo, ctx.sr_repo
     )

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -2,7 +2,6 @@ import pytest
 
 from domain.delivery_request import RequestItem, Status as DRStatus
 from app.use_cases import submit_delivery_request, void_sales_report
-from domain.sales_report import ReportItem
 from policies.active_delivery_request import ActiveDeliveryRequestExists
 from policies.identity import Actor, Role
 from policies.report_required import ReportRequired

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,12 +1,13 @@
 import pytest
 
 from domain.delivery_request import RequestItem, Status as DRStatus
-from app.use_cases import submit_delivery_request
+from app.use_cases import submit_delivery_request, void_sales_report
 from domain.sales_report import ReportItem
 from policies.active_delivery_request import ActiveDeliveryRequestExists
 from policies.identity import Actor, Role
+from policies.report_required import ReportRequired
 from policies.stock_projection import compute_partner_stock
-from tests.helpers import given_dr, given_sr
+from tests.helpers import default_items, given_dr, given_sr
 
 """ ARD: ActiveRequestDelivery policy """
 
@@ -70,84 +71,57 @@ def test_compute_partner_stock_empty(ctx):
     assert stock == {}
 
 
-def test_compute_partner_stock_with_deliveries_only(ctx):
-    _ = given_dr(
-        ctx, "p1", DRStatus.DELIVERED, items=[RequestItem(book_id="b1", quantity=3)]
-    )
+def test_compute_partner_stock_with_deliveries_only(ctx, partner_actor):
     _ = given_dr(
         ctx,
-        "p1",
+        partner_actor.partner_id,
         DRStatus.DELIVERED,
-        items=[
-            RequestItem(book_id="b1", quantity=2),
-            RequestItem(book_id="b2", quantity=5),
-        ],
     )
-    stock = compute_partner_stock("p1", ctx.dr_repo, ctx.sr_repo)
-    assert stock == {"b1": 5, "b2": 5}
+
+    # report required policy will prevent the following delivery to succeed
+    with pytest.raises(ReportRequired):
+        _ = given_dr(
+            ctx,
+            "p1",
+            DRStatus.DELIVERED,
+            items=[
+                RequestItem(book_id="b1", quantity=2),
+                RequestItem(book_id="b2", quantity=5),
+            ],
+        )
+    stock = compute_partner_stock(partner_actor.partner_id, ctx.dr_repo, ctx.sr_repo)
+    assert stock == {r.book_id: r.quantity for r in default_items()}
 
 
-def test_compute_partner_stock_with_deliveries_and_sales(ctx):
-    _ = given_dr(
-        ctx, "p1", DRStatus.DELIVERED, items=[RequestItem(book_id="b1", quantity=3)]
-    )
-    _ = given_dr(
-        ctx,
-        "p1",
-        DRStatus.DELIVERED,
-        items=[
-            RequestItem(book_id="b1", quantity=2),
-            RequestItem(book_id="b2", quantity=5),
-        ],
-    )
-    _ = given_sr(
-        ctx,
-        "p1",
-        items=[
-            ReportItem(book_id="b1", quantity=4),
-            ReportItem(book_id="b2", quantity=1),
-        ],
-    )
-    stock = compute_partner_stock("p1", ctx.dr_repo, ctx.sr_repo)
-    assert stock == {"b1": 1, "b2": 4}
+def test_compute_partner_stock_with_deliveries_and_sales(ctx, partner_actor):
+    _ = given_dr(ctx, partner_actor.partner_id, DRStatus.DELIVERED)
+    _ = given_sr(ctx, partner_actor.partner_id)
+    stock = compute_partner_stock(partner_actor.partner_id, ctx.dr_repo, ctx.sr_repo)
+    assert stock == {"b1": 2, "b2": 1}
 
 
 def test_compute_partner_stock_ignores_other_partners(ctx):
-    _ = given_dr(
-        ctx, "p1", DRStatus.DELIVERED, items=[RequestItem(book_id="b1", quantity=3)]
-    )
-    _ = given_dr(
-        ctx,
-        "p2",
-        DRStatus.DELIVERED,
-        items=[
-            RequestItem(book_id="b1", quantity=2),
-            RequestItem(book_id="b2", quantity=5),
-        ],
-    )
-    _ = given_sr(
-        ctx,
-        "p2",
-        items=[
-            ReportItem(book_id="b1", quantity=4),
-            ReportItem(book_id="b2", quantity=1),
-        ],
-    )
-    stock = compute_partner_stock("p1", ctx.dr_repo, ctx.sr_repo)
-    assert stock == {"b1": 3}
+    _ = given_dr(ctx, "p1", DRStatus.DELIVERED)
+    _ = given_dr(ctx, "p2", DRStatus.DELIVERED)
+    _ = given_sr(ctx, "p2")
+
+    stock_p1 = compute_partner_stock("p1", ctx.dr_repo, ctx.sr_repo)
+    assert stock_p1 == {"b1": 2, "b2": 3}
+
+    stock_p2 = compute_partner_stock("p2", ctx.dr_repo, ctx.sr_repo)
+    assert stock_p2 == {"b1": 2, "b2": 1}
 
 
-def test_compute_partner_stock_ignores_voided_sales(ctx):
-    _ = given_dr(
-        ctx, "p1", DRStatus.DELIVERED, items=[RequestItem(book_id="b1", quantity=3)]
+def test_compute_partner_stock_ignores_voided_sales(ctx, admin_actor, partner_actor):
+    _ = given_dr(ctx, partner_actor.partner_id, DRStatus.DELIVERED)
+    _ = given_sr(ctx, partner_actor.partner_id)
+    stock_before_void = compute_partner_stock(
+        partner_actor.partner_id, ctx.dr_repo, ctx.sr_repo
     )
-    _ = given_sr(
-        ctx,
-        "p1",
-        items=[
-            ReportItem(book_id="b1", quantity=4),
-        ],
-        voided=True,
+    assert stock_before_void == {"b1": 2, "b2": 1}
+
+    void_sales_report(ctx, admin_actor, 1, reason="test void")
+    stock_after_void = compute_partner_stock(
+        partner_actor.partner_id, ctx.dr_repo, ctx.sr_repo
     )
-    stock = compute_partner_stock("p1", ctx.dr_repo, ctx.sr_repo)
-    assert stock == {"b1": 3}
+    assert stock_after_void == {"b1": 2, "b2": 3}

--- a/tests/test_report_required_policy.py
+++ b/tests/test_report_required_policy.py
@@ -1,55 +1,39 @@
 import pytest
+from app.use_cases import create_delivery_request, submit_delivery_request
 from domain.delivery_request import DeliveryRequest, RequestItem, Status as DRStatus
-from domain.sales_report import SalesReport, ReportItem
-from app import use_cases as uc
 from policies.report_required import ReportRequired
+from tests.helpers import given_dr, given_sr
 
 
 def test_submit_dr_allowed_if_no_delivered_dr_exists(ctx, partner_actor):
-    rk, _ = uc.create_delivery_request(
+    rk, _ = create_delivery_request(
         ctx=ctx, actor=partner_actor, payload=[RequestItem(book_id="b1", quantity=2)]
     )
-    _, dr = uc.submit_delivery_request(ctx=ctx, actor=partner_actor, dr_id=rk)
+    _, dr = submit_delivery_request(ctx=ctx, actor=partner_actor, dr_id=rk)
     assert dr.status is DRStatus.SUBMITTED
 
 
 def test_submit_dr_blocked_if_last_delivery_has_no_sr_after(ctx, partner_actor):
     # Last delivered DR for p1 exists
-    ctx.dr_repo.create(
-        DeliveryRequest(
-            partner_id="p1",
-            status=DRStatus.DELIVERED,
-            items=[RequestItem(book_id="b1", quantity=2)],
-        )
-    )
+    _ = given_dr(ctx, partner_actor.partner_id, DRStatus.DELIVERED)
 
     with pytest.raises(ReportRequired):
-        rk, _ = uc.create_delivery_request(
+        rk, _ = create_delivery_request(
             ctx=ctx,
             actor=partner_actor,
             payload=[RequestItem(book_id="b1", quantity=3)],
         )
-        uc.submit_delivery_request(ctx=ctx, actor=partner_actor, dr_id=rk)
+        submit_delivery_request(ctx=ctx, actor=partner_actor, dr_id=rk)
 
 
 def test_submit_dr_allowed_if_sr_exists_after_last_delivery(ctx, partner_actor):
-    items = [RequestItem(book_id="b1", quantity=2)]
-    ctx.dr_repo.create(
-        DeliveryRequest(partner_id="p1", status=DRStatus.DELIVERED, items=items)
-    )
-
-    # SR submitted after delivery (order is shared)
-    ctx.sr_repo.create(
-        SalesReport(partner_id="p1", items=[ReportItem(book_id="b1", quantity=2)])
-    )
-
-    rk, _ = uc.create_delivery_request(
-        ctx=ctx, actor=partner_actor, payload=[RequestItem(book_id="b2", quantity=4)]
-    )
-    _, dr = uc.submit_delivery_request(
+    _ = given_dr(ctx, partner_actor.partner_id, DRStatus.DELIVERED)
+    _ = given_sr(ctx, partner_actor.partner_id)
+    dr_id = given_dr(ctx, partner_actor.partner_id, DRStatus.DRAFT)
+    _, dr = submit_delivery_request(
         ctx=ctx,
         actor=partner_actor,
-        dr_id=rk,
+        dr_id=dr_id,
     )
 
     assert dr.status is DRStatus.SUBMITTED

--- a/tests/test_sales_report.py
+++ b/tests/test_sales_report.py
@@ -2,62 +2,66 @@ import pytest
 
 from domain.sales_report import SalesReport, ReportItem
 from domain.errors import InvalidReport
-from app.queries import reports_by_partner
 from policies.validations import validate_report_items_in_catalog
+from tests.helpers import default_sales
+
 
 def test_sales_report_rejects_non_positive_quantities():
-  with pytest.raises(InvalidReport):
-    SalesReport(partner_id="p1", items=[ReportItem(book_id="b1", quantity=0)])
+    with pytest.raises(InvalidReport):
+        SalesReport(
+            id=None, partner_id="p1", items=[ReportItem(book_id="b1", quantity=0)]
+        )
+
 
 def test_sales_report_rejects_empty_items_list():
-  with pytest.raises(InvalidReport):
-    SalesReport(partner_id="p1", items=[])
+    with pytest.raises(InvalidReport):
+        SalesReport(id=None, partner_id="p1", items=[])
+
 
 def test_sales_report_rejects_empty_partner_id():
-  with pytest.raises(InvalidReport):
-    SalesReport(partner_id="", items=[ReportItem(book_id="b1", quantity=2)])
+    with pytest.raises(InvalidReport):
+        SalesReport(id=None, partner_id="", items=default_sales())
+
 
 def test_sales_report_total_quantity_lt_min_fails():
-  with pytest.raises(InvalidReport):
-    SalesReport(partner_id="p1", items=[ReportItem(book_id="b1", quantity=1)])
+    with pytest.raises(InvalidReport):
+        SalesReport(
+            id=None, partner_id="p1", items=[ReportItem(book_id="b1", quantity=1)]
+        )
+
 
 def test_sales_report_total_quantity_ge_min_succeeds():
-  r1 = SalesReport(
-    partner_id="p1",
-    items=[
-      ReportItem(book_id="b1", quantity=1),
-      ReportItem(book_id="b2", quantity=3)
-    ]
-  )
-  assert r1.partner_id == "p1"
+    r1 = SalesReport(
+        id=None,
+        partner_id="p1",
+        items=[
+            ReportItem(book_id="b1", quantity=1),
+            ReportItem(book_id="b2", quantity=3),
+        ],
+    )
+    assert r1.partner_id == "p1"
+
 
 def test_sales_report_rejects_duplicate():
-  with pytest.raises(InvalidReport):
-    SalesReport(
-      partner_id="p1",
-      items=[
-        ReportItem(book_id="b1", quantity=1),
-        ReportItem(book_id="b1", quantity=3)
-      ]
-   )
+    with pytest.raises(InvalidReport):
+        SalesReport(
+            id=None,
+            partner_id="p1",
+            items=[
+                ReportItem(book_id="b1", quantity=1),
+                ReportItem(book_id="b1", quantity=3),
+            ],
+        )
+
 
 def test_validate_report_items_in_catalog():
-  r1 = SalesReport(
-      partner_id="p1",
-      items=[
-        ReportItem(book_id="b1", quantity=1),
-        ReportItem(book_id="b5", quantity=3)
-      ]
-   )
-  with pytest.raises(InvalidReport):
-    validate_report_items_in_catalog(r1, {"b1"})
-
-
-def test_reports_by_partner_filters():
-  r1 = SalesReport(partner_id="p1", items=[ReportItem(book_id="b1", quantity=2)])
-  r2 = SalesReport(partner_id="p2", items=[ReportItem(book_id="b1", quantity=2)])
-  r3 = SalesReport(partner_id="p1", items=[ReportItem(book_id="b2", quantity=3)])
-
-  got = reports_by_partner([r1, r2, r3], partner_id="p1")
-
-  assert got == [r1, r3]
+    r1 = SalesReport(
+        id=None,
+        partner_id="p1",
+        items=[
+            ReportItem(book_id="b1", quantity=1),
+            ReportItem(book_id="b5", quantity=3),
+        ],
+    )
+    with pytest.raises(InvalidReport):
+        validate_report_items_in_catalog(r1, {"b1"})

--- a/tests/test_sql_delivery_request_repo.py
+++ b/tests/test_sql_delivery_request_repo.py
@@ -1,10 +1,11 @@
-import pytest
-from domain.delivery_request import DeliveryRequest, RequestItem
-from app.helpers import get_dr_or_raise
+from domain.delivery_request import DeliveryRequest, RequestItem, Status as DRStatus
+from tests.helpers import given_dr
 
 
-def test_create_and_get_dr(ctx):
-    dr = DeliveryRequest.save_draft(partner_id="luigi", items=[RequestItem("b1", 3)])
+def test_create_and_get_dr(ctx, partner_actor):
+    dr = DeliveryRequest.save_draft(
+        partner_id=partner_actor.partner_id, items=[RequestItem("b1", 3)]
+    )
 
     dr_id = ctx.dr_repo.create(dr)
 
@@ -13,21 +14,8 @@ def test_create_and_get_dr(ctx):
     assert loaded.items == [RequestItem("b1", 3)]
 
 
-def test_save(ctx):
-    dr = DeliveryRequest.save_draft(partner_id="luigi", items=[RequestItem("b1", 3)])
-
-    dr_id = ctx.dr_repo.create(dr)
+def test_save(ctx, partner_actor):
+    dr_id = given_dr(ctx, partner_actor.partner_id, DRStatus.DRAFT)
 
     loaded = ctx.dr_repo.get(dr_id)
-    loaded = loaded.submit()
-    ctx.dr_repo.save(loaded)
-
-    loaded = ctx.dr_repo.get(dr_id)
-    assert loaded.status == "SUBMITTED"
-
-    loaded = ctx.dr_repo.get(dr_id)
-    loaded = loaded.approve()
-    ctx.dr_repo.save(loaded)
-
-    loaded = ctx.dr_repo.get(dr_id)
-    assert loaded.status == "APPROVED"
+    assert loaded.status == DRStatus.DRAFT

--- a/tests/test_sql_delivery_request_repo.py
+++ b/tests/test_sql_delivery_request_repo.py
@@ -1,5 +1,6 @@
 import pytest
 from domain.delivery_request import DeliveryRequest, RequestItem
+from app.helpers import get_dr_or_raise
 
 
 def test_create_and_get_dr(ctx):
@@ -18,15 +19,15 @@ def test_save_status(ctx):
     dr_id = ctx.dr_repo.create(dr)
 
     loaded = ctx.dr_repo.get(dr_id)
-    loaded.submit()
-    ctx.dr_repo.save_status(dr_id, loaded.status)
+    loaded = loaded.submit()
+    ctx.dr_repo.save_status(loaded)
 
     loaded = ctx.dr_repo.get(dr_id)
     assert loaded.status == "SUBMITTED"
 
     loaded = ctx.dr_repo.get(dr_id)
-    loaded.approve()
-    ctx.dr_repo.save_status(dr_id, loaded.status)
+    loaded = loaded.approve()
+    ctx.dr_repo.save_status(loaded)
 
     loaded = ctx.dr_repo.get(dr_id)
     assert loaded.status == "APPROVED"

--- a/tests/test_sql_delivery_request_repo.py
+++ b/tests/test_sql_delivery_request_repo.py
@@ -13,21 +13,21 @@ def test_create_and_get_dr(ctx):
     assert loaded.items == [RequestItem("b1", 3)]
 
 
-def test_save_status(ctx):
+def test_save(ctx):
     dr = DeliveryRequest.save_draft(partner_id="luigi", items=[RequestItem("b1", 3)])
 
     dr_id = ctx.dr_repo.create(dr)
 
     loaded = ctx.dr_repo.get(dr_id)
     loaded = loaded.submit()
-    ctx.dr_repo.save_status(loaded)
+    ctx.dr_repo.save(loaded)
 
     loaded = ctx.dr_repo.get(dr_id)
     assert loaded.status == "SUBMITTED"
 
     loaded = ctx.dr_repo.get(dr_id)
     loaded = loaded.approve()
-    ctx.dr_repo.save_status(loaded)
+    ctx.dr_repo.save(loaded)
 
     loaded = ctx.dr_repo.get(dr_id)
     assert loaded.status == "APPROVED"

--- a/tests/test_sql_delivery_request_repo.py
+++ b/tests/test_sql_delivery_request_repo.py
@@ -14,8 +14,15 @@ def test_create_and_get_dr(ctx, partner_actor):
     assert loaded.items == [RequestItem("b1", 3)]
 
 
-def test_save(ctx, partner_actor):
+def test_save_dr(ctx, partner_actor):
     dr_id = given_dr(ctx, partner_actor.partner_id, DRStatus.DRAFT)
 
     loaded = ctx.dr_repo.get(dr_id)
     assert loaded.status == DRStatus.DRAFT
+
+    # mutate status and save
+    loaded = loaded.submit()
+    ctx.dr_repo.save(loaded)
+
+    reloaded = ctx.dr_repo.get(dr_id)
+    assert reloaded.status == DRStatus.SUBMITTED

--- a/tests/test_sql_sales_report_repo.py
+++ b/tests/test_sql_sales_report_repo.py
@@ -1,9 +1,10 @@
-import pytest
 from domain.sales_report import SalesReport, ReportItem
 
 
-def test_create_and_get_sr(ctx):
-    sr = SalesReport(partner_id="luigi", items=[ReportItem("b1", 3)])
+def test_create_and_get_sr(ctx, partner_actor):
+    sr = SalesReport(
+        id=None, partner_id=partner_actor.partner_id, items=[ReportItem("b1", 3)]
+    )
 
     sr_id = ctx.sr_repo.create(sr)
 
@@ -16,8 +17,10 @@ def test_create_and_get_sr(ctx):
 # def test_get_non_existent_sr(ctx):
 
 
-def test_mark_sr_as_voided(ctx):
-    sr = SalesReport(partner_id="luigi", items=[ReportItem("b1", 3)])
+def test_mark_sr_as_voided(ctx, partner_actor):
+    sr = SalesReport(
+        id=None, partner_id=partner_actor.partner_id, items=[ReportItem("b1", 3)]
+    )
 
     sr_id = ctx.sr_repo.create(sr)
 

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -55,10 +55,10 @@ def test_submit_sales_report_requires_known_book_ids(ctx, partner_actor):
 
 
 def test_submit_sales_report_rejects_quantities_gt_stock(ctx, partner_actor):
-    # Stock entrant: 1 de b1 et 3 de b2livré au partenaire
+    # Stock entrant: 2 examplaires de b1 et 3 de b2 livrés au partenaire
     _ = given_dr(ctx, partner_actor.partner_id, Status.DELIVERED)
 
-    # Ventes déclarées: 3 exemplaires => dépasse le stock entrant (2)
+    # Ventes déclarées: 3 exemplaires de b1 => dépasse le stock entrant (2)
     with pytest.raises(InsufficientStock):
         submit_sales_report(
             ctx=ctx,
@@ -105,64 +105,6 @@ def test_partner_cannot_submit_another_partner_delivery_request(ctx):
 
     with pytest.raises(Forbidden):
         submit_delivery_request(ctx, p2, dr_id)
-
-
-# def test_list_reports_by_partner_filters_for_admin(admin_actor, sr_repo):
-#     r1 = SalesReport(partner_id="p1", items=[ReportItem(book_id="b1", quantity=3)])
-#     r2 = SalesReport(partner_id="p1", items=[ReportItem(book_id="b2", quantity=2)])
-#     r3 = SalesReport(partner_id="p2", items=[ReportItem(book_id="b1", quantity=4)])
-
-#     sr_repo.add(r1)
-#     sr_repo.add(r2)
-#     sr_repo.add(r3)
-
-#     result = list_reports_by_partner(
-#         actor=admin_actor, partner_id="p1", sr_repo=sr_repo
-#     )
-
-#     assert result == [r1, r2]
-
-
-# def test_list_reports_by_partner_returns_empty_list_if_none(admin_actor, sr_repo):
-#     result = list_reports_by_partner(
-#         actor=admin_actor, partner_id="p1", sr_repo=sr_repo
-#     )
-#     assert result == []
-
-
-# def test_list_reports_by_partner_rejects_partner(partner_actor, sr_repo):
-#     with pytest.raises(Forbidden):
-#         list_reports_by_partner(
-#             actor=partner_actor, partner_id=partner_actor.partner_id, sr_repo=sr_repo
-#         )
-
-
-# def test_list_my_reports_rejects_admin(admin_actor, sr_repo):
-#     with pytest.raises(Forbidden):
-#         list_my_reports(actor=admin_actor, sr_repo=sr_repo)
-
-
-# def test_list_my_reports_happy_path(partner_actor, sr_repo):
-#     r1 = SalesReport(
-#         partner_id=partner_actor.partner_id,
-#         items=[ReportItem(book_id="b1", quantity=3)],
-#     )
-#     r2 = SalesReport(
-#         partner_id=partner_actor.partner_id,
-#         items=[ReportItem(book_id="b2", quantity=2)],
-#     )
-#     r3 = SalesReport(partner_id="p2", items=[ReportItem(book_id="b1", quantity=4)])
-
-#     sr_repo.add(r1)
-#     sr_repo.add(r2)
-#     sr_repo.add(r3)
-
-#     a3 = Actor(role=Role.PARTNER, partner_id="p3")
-
-#     result = list_my_reports(actor=partner_actor, sr_repo=sr_repo)
-#     assert result == [r1, r2]
-#     result = list_my_reports(actor=a3, sr_repo=sr_repo)
-#     assert result == []
 
 
 def test_create_delivery_request_requires_known_book_ids(ctx, partner_actor):

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -10,17 +10,16 @@ from app.use_cases import (
     submit_sales_report,
     void_sales_report,
 )
-from domain.errors import InvalidReport
+from domain.errors import InvalidReport, InsufficientStock
 from app.errors import NotFound, ValidationError
-from domain.sales_report import ReportItem, SalesReport, AlreadyVoided
+from domain.sales_report import ReportItem, AlreadyVoided
 from domain.delivery_request import (
     InvalidDeliveryRequest,
     Status,
     RequestItem,
-    DeliveryRequest,
 )
 from policies.identity import Forbidden, Role, Actor
-from policies.validations import InsufficientStock, compute_partner_stock
+from policies.stock_projection import compute_partner_stock
 from tests.helpers import given_dr, given_sr
 
 
@@ -56,17 +55,10 @@ def test_submit_sales_report_requires_known_book_ids(ctx, partner_actor):
 
 
 def test_submit_sales_report_rejects_quantities_gt_stock(ctx, partner_actor):
-    # Stock entrant: 1 exemplaire de b1 livré au partenaire
-    dr = DeliveryRequest.save_draft(
-        partner_id=partner_actor.partner_id,
-        items=[RequestItem(book_id="b1", quantity=2)],
-    )
-    dr.submit()
-    dr.approve()
-    dr.mark_delivered()
-    ctx.dr_repo.create(dr)
+    # Stock entrant: 1 de b1 et 3 de b2livré au partenaire
+    _ = given_dr(ctx, partner_actor.partner_id, Status.DELIVERED)
 
-    # Ventes déclarées: 2 exemplaires => dépasse le stock entrant (1)
+    # Ventes déclarées: 3 exemplaires => dépasse le stock entrant (2)
     with pytest.raises(InsufficientStock):
         submit_sales_report(
             ctx=ctx,
@@ -183,7 +175,7 @@ def test_create_delivery_request_requires_known_book_ids(ctx, partner_actor):
 
 
 def test_submit_allowed_when_no_previous_delivery_exists(ctx, partner_actor):
-    dr_id, dr = create_delivery_request(
+    dr_id, _ = create_delivery_request(
         ctx=ctx,
         actor=partner_actor,
         payload=[RequestItem(book_id="b1", quantity=2)],
@@ -263,6 +255,7 @@ def test_mark_delivered_dr_not_found(ctx, admin_actor):
 
 
 def test_void_sales_report_requires_admin(ctx, partner_actor):
+    _ = given_dr(ctx, partner_actor.partner_id, Status.DELIVERED)
     sr_id = given_sr(ctx, partner_actor.partner_id)
     with pytest.raises(Forbidden):
         void_sales_report(ctx, partner_actor, sr_id, "invalid report")
@@ -271,8 +264,9 @@ def test_void_sales_report_requires_admin(ctx, partner_actor):
     assert ctx.audit.list_all() == []
 
 
-def test_void_sales_report_requires_reason(ctx, admin_actor):
-    sr_id = given_sr(ctx, "p1")
+def test_void_sales_report_requires_reason(ctx, admin_actor, partner_actor):
+    _ = given_dr(ctx, partner_actor.partner_id, Status.DELIVERED)
+    sr_id = given_sr(ctx, partner_actor.partner_id)
     with pytest.raises(ValidationError):
         void_sales_report(ctx, admin_actor, sr_id, "")
 
@@ -287,6 +281,7 @@ def test_void_sales_report_not_found(ctx, admin_actor):
 
 def test_void_sales_report_happy_path(ctx, admin_actor):
     """voids_report_and_records_audit"""
+    _ = given_dr(ctx, "p1", Status.DELIVERED)
     sr_id = given_sr(ctx, "p1")
     _, report = void_sales_report(ctx, admin_actor, sr_id, "invalid report")
 
@@ -299,8 +294,9 @@ def test_void_sales_report_happy_path(ctx, admin_actor):
     assert audit_event["reason"] == "invalid report"
 
 
-def test_void_sales_report_already_voided_raises(ctx, admin_actor):
-    sr_id = given_sr(ctx, "p1")
+def test_void_sales_report_already_voided_raises(ctx, admin_actor, partner_actor):
+    _ = given_dr(ctx, partner_actor.partner_id, Status.DELIVERED)
+    sr_id = given_sr(ctx, partner_actor.partner_id)
     void_sales_report(ctx, admin_actor, sr_id, "invalid report")
     with pytest.raises(AlreadyVoided):
         void_sales_report(ctx, admin_actor, sr_id, "invalid report")

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -18,6 +18,7 @@ from domain.delivery_request import (
     Status,
     RequestItem,
 )
+from infra.errors import DataIntegrityError
 from policies.identity import Forbidden, Role, Actor
 from policies.stock_projection import compute_partner_stock
 from tests.helpers import given_dr, given_sr
@@ -261,3 +262,51 @@ def test_void_sales_report_already_voided_raises(ctx, admin_actor, partner_actor
 def test_get_sales_report_not_found_raises_not_found(ctx, admin_actor):
     with pytest.raises(NotFound):
         get_sales_report(ctx, admin_actor, 999)
+
+
+def test_void_sales_report_with_missing_inventory_line(ctx, admin_actor, partner_actor):
+
+    _ = given_dr(
+        ctx,
+        partner_actor.partner_id,
+        Status.DELIVERED,
+        items=[
+            RequestItem(book_id="b1", quantity=4),
+            RequestItem(book_id="b2", quantity=4),
+            RequestItem(book_id="b3", quantity=4),
+        ],
+    )  # 4, 4, 4 livrés au partenaire
+    sr_id = given_sr(
+        ctx,
+        partner_actor.partner_id,
+        items=[
+            ReportItem(book_id="b3", quantity=1),
+            ReportItem(book_id="b2", quantity=2),
+        ],
+    )  # 4, 4, 4 -> 4, 2, 3 (restant en stock)
+
+    pi3 = ctx.pi_repo.get(partner_actor.partner_id, "b3")
+    pi2 = ctx.pi_repo.get(partner_actor.partner_id, "b2")
+    pi1 = ctx.pi_repo.get(partner_actor.partner_id, "b1")
+
+    assert pi3 and pi3.current_quantity == 3
+    assert pi2 and pi2.current_quantity == 2
+    assert pi1 and pi1.current_quantity == 4
+
+    # let us delete the inventory line for b3 to simulate the missing inventory line scenario during voiding
+
+    ctx.pi_repo.conn.execute(
+        "DELETE FROM partner_inventories WHERE partner_id = ? AND book_sku = ?",
+        (partner_actor.partner_id, "b3"),
+    )
+    ctx.pi_repo.conn.commit()
+
+    pi3 = ctx.pi_repo.get(partner_actor.partner_id, "b3")
+    assert pi3 is None
+
+    with pytest.raises(
+        DataIntegrityError,
+        match="contains following items \\(b3\\), for which no inventory line exists",
+        # match="sales report with id .* contains book_id\\(s\\) b3 for which no inventory line exists",
+    ):
+        void_sales_report(ctx, admin_actor, sr_id, "invalid report")


### PR DESCRIPTION
- [x] Understand the issue: `pi is None` in `void_sales_report` silently returns early instead of raising an error
- [x] Create `infra/errors.py` with `DataIntegrityError` (with docstring)
- [x] Update `app/use_cases.py` `void_sales_report` to raise `DataIntegrityError` when inventory lines are missing, including partner_id and book_ids in the error message
- [x] All 122 tests pass
- [x] Code review addressed (error message specificity, docstring)
- [x] No CodeQL security alerts